### PR TITLE
Fixed attribute replacement when no path was specified

### DIFF
--- a/tasks/lib/htmlprocessor.js
+++ b/tasks/lib/htmlprocessor.js
@@ -79,7 +79,7 @@ var getBlockTypes = function (options, filePath) {
       var re = new RegExp('(\\s*(?:' + block.attr + ')=[\'"])(.*)?(".*)', 'gi');
       var replacedBlock = blockContent.replace(re, function (wholeMatch, start, asset, end) {
         // check if only the path was provided to leave the original asset name intact
-        asset = !path.extname(block.asset) ? block.asset + path.basename(asset) : block.asset;
+        asset = (!path.extname(block.asset) && /\//.test(block.asset))? block.asset + path.basename(asset) : block.asset;
         return start + asset + end;
       });
       return content.replace(blockLine, replacedBlock);


### PR DESCRIPTION
Previously replacing a class -- e.g. class="debug" with a value of
"production" would result in class="productiondebug". It will now
replace debug with production as expected and will only preserve the
original asset name if the forward slash character is found in the
block asset.
