### PR TITLE
htmlprocessor accepts comma-separated lists

### DIFF
--- a/tasks/lib/htmlprocessor.js
+++ b/tasks/lib/htmlprocessor.js
@@ -40,7 +40,7 @@ var getBlocks = function (content, marker) {
       block = {
         type: attr ? 'attr': build[1],
         attr: attr,
-        targets: build[2].split(','),
+        targets: !!build[2] ? build[2].split(',') : null,
         asset: build[3],
         indent: /^\s*/.exec(line)[0],
         raw: []


### PR DESCRIPTION
You can now pass comment blocks of the form: `<!-- build:<type>[:targets] [value] -->` where `targets` is a comma-separated list of targets, e.g. `<!-- build:<type>:dist,dev [value] -->`
