### PR TITLE
Add 'inline' modifier for embedding javascript and css

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -60,6 +60,13 @@ module.exports = ->
         files:
           "test/fixtures/strip/strip.processed.html": ["test/fixtures/strip.html"]
 
+      inline:
+        options:
+          environment: null
+
+        files:
+          "test/fixtures/inline/inline.processed.html": ["test/fixtures/inline.html"]
+
       ###
       The following three tests are for describing multiple targets
       ###

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ grunt.loadNpmTasks('grunt-processhtml');
 Process `html` files with special comments:
 
 ```html
-<!-- build:<type>[:target] [value] -->
+<!-- build:<type>[:target] [inline] [value] -->
 ...
 <!-- /build -->
 ```
@@ -43,20 +43,27 @@ Is the target name of your grunt task, for example: `dist`. Is supported for all
 
 You can pass multiple comma-separated targets, e.g. `<!-- build:remove:dist,dev,prod -->` and block will be parsed for each.
 
+##### inline
+This modifier can be used with `js` and `css` types.
+
+If used styles or scripts will be included in the output html file.
+
 ##### value
 Required for types: `js`, `css`, `include` and `[attr]`.
 
-Optional for types: `remove`, `template`.
+Optional for types: `remove`, `template` and `js`, `css` types with `inline` modifier.
 
 Could be a file name: `script.min.js` or a path if an attribute like `[src]` is specified to keep the original file name intact but replace its path.
 
 ### Simple examples
 
-##### `build:js[:targets] <value>`
+##### `build:js[:targets] [inline] <value>`
 
 Replace many script tags into one.
 
 `[:targets]` Optional build targets.
+
+`inline` Optional modifier.
 
 `<value>` Required value: A file path.
 
@@ -70,11 +77,42 @@ Replace many script tags into one.
 <script src="app.min.js"></script>
 ```
 
-##### `build:css[:targets] <value>`
+You can embed your javascript:
+
+```html
+<!-- build:js inline app.min.js -->
+<script src="my/lib/path/lib.js"></script>
+<script src="my/deep/development/path/script.js"></script>
+<!-- /build -->
+
+<!-- changed to -->
+<script>
+  // app.min.js code here
+</script>
+```
+
+or
+
+```html
+<!-- build:js inline -->
+<script src="my/lib/path/lib.js"></script>
+<script src="my/deep/development/path/script.js"></script>
+<!-- /build -->
+
+<!-- changed to -->
+<script>
+  // my/lib/path/lib.js code here then...
+  // my/deep/development/path/script.js code goes here
+</script>
+```
+
+##### `build:css[:targets] [inline] <value>`
 
 Replace many stylesheet link tags into one.
 
 `[:targets]` Optional build targets.
+
+`inline` Optional modifier.
 
 `<value>` Required value: A file path.
 
@@ -86,6 +124,35 @@ Replace many stylesheet link tags into one.
 
 <!-- changed to -->
 <link rel="stylesheet" href="style.min.css">
+```
+
+You can embed your styles like with `js` type above:
+
+```html
+<!-- build:css inline -->
+<link rel="stylesheet" href="path/to/normalize.css">
+<link rel="stylesheet" href="path/to/main.css">
+<!-- /build -->
+
+<!-- changed to -->
+<style>
+  /* path/to/normalize.css */
+  /* path/to/main.css */
+</style>
+```
+
+or
+
+```html
+<!-- build:css inline style.min.css -->
+<link rel="stylesheet" href="path/to/normalize.css">
+<link rel="stylesheet" href="path/to/main.css">
+<!-- /build -->
+
+<!-- changed to -->
+<style>
+  /* style.min.css */
+</style>
 ```
 
 ##### `build:<[attr]>[:targets] <value>`
@@ -502,6 +569,7 @@ The `custom.html` to be processed:
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+- 0.3.7 Update [node-htmlprocessor](https://github.com/dciccale/node-htmlprocessor) dependency with added `inline` modifier
 - 0.3.6 Update node-htmlprocessor version and add specific test for templates
 - 0.3.5 Fixes issue when passing data to a `template`
 - 0.3.4 Fixes issue when passing a path te replace an `[attr]`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-processhtml",
   "description": "Process html files at build time to modify them depending on the release environment",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "homepage": "https://github.com/dciccale/grunt-processhtml",
   "author": {
     "name": "Denis Ciccale",
@@ -29,7 +29,8 @@
     "test": "grunt --verbose"
   },
   "dependencies": {
-    "htmlprocessor": "0.1.9"
+    "async": "^0.9.0",
+    "htmlprocessor": "0.1.10"
   },
   "devDependencies": {
     "grunt": "0.4.1",

--- a/test/expected/inline/inline.html
+++ b/test/expected/inline/inline.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Inline CSS</title>
+
+    <link rel="stylesheet" href="styles.css">
+
+    <style>
+html {
+    padding: 0;
+}
+
+html {
+    padding: 0;
+}
+    </style>
+
+    <style>
+html {
+    padding: 0;
+}
+    </style>
+
+</head>
+<body>
+
+    <script src="script_include.js"></script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+</body>
+</html>

--- a/test/fixtures/inline.html
+++ b/test/fixtures/inline.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Inline CSS</title>
+
+    <!-- build:css styles.css -->
+    <link rel="stylesheet" href="styles1.css">
+    <link rel="stylesheet" href="styles2.css">
+    <!-- /build -->
+
+    <!-- build:css:dist inline -->
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css">
+    <!-- /build -->
+
+    <!-- build:css:dist inline styles.css -->
+    <link rel="stylesheet" href="styles1.css">
+    <link rel="stylesheet" href="styles2.css">
+    <!-- /build -->
+
+</head>
+<body>
+
+    <!-- build:js script_include.js -->
+    <script src="js/app/script1.js"></script>
+    <script src="js/app/script2.js"></script>
+    <!-- /build -->
+
+    <!-- build:js inline -->
+    <script src="script_include.js"></script>
+    <script src="script_include.js"></script>
+    <script src="script_include.js"></script>
+    <!-- /build -->
+
+    <!-- build:js:dist inline script_include.js -->
+    <script src="js/app/main.js"></script>
+    <script src="js/app/module.js"></script>
+    <!-- /build -->
+
+</body>
+</html>

--- a/test/fixtures/inline/inline.processed.html
+++ b/test/fixtures/inline/inline.processed.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Inline CSS</title>
+
+    <link rel="stylesheet" href="styles.css">
+
+    <style>
+html {
+    padding: 0;
+}
+
+html {
+    padding: 0;
+}
+    </style>
+
+    <style>
+html {
+    padding: 0;
+}
+    </style>
+
+</head>
+<body>
+
+    <script src="script_include.js"></script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+</body>
+</html>

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,0 +1,3 @@
+html {
+    padding: 0;
+}

--- a/test/processhtml_test.js
+++ b/test/processhtml_test.js
@@ -119,5 +119,15 @@ exports.processhtml = {
     test.equal(actual, expected, 'define custom block types');
 
     test.done();
+  },
+
+  inline: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('test/fixtures/inline/inline.processed.html');
+    var expected = grunt.file.read('test/expected/inline/inline.html');
+    test.equal(actual, expected, 'inline (embedd) css and js files');
+
+    test.done();
   }
 };


### PR DESCRIPTION
See [node-htmlprocessor](https://github.com/dciccale/node-htmlprocessor/pull/7) pull request.

- update htmlprocessor dependency to ~0.1.6
- add tests for 'inline' modifier
- use async() grunt feature
