### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Type: `String`
 Default value: `build`
 
 Specify the word used to indicate the special begin/end comments.  This is useful if you want to use this plugin
-in conjuction with other plugins that use a similar, conflicting `build:<type>` comment
+in conjunction with other plugins that use a similar, conflicting `build:<type>` comment
 (such as [grunt-usemin](https://github.com/yeoman/grunt-usemin)).
 
 With `options.commentMarker` set to `process`, a typical comment would look like:


### PR DESCRIPTION
@dciccale, I've corrected a typographical error in the documentation of the [grunt-processhtml](https://github.com/dciccale/grunt-processhtml) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.