### PR TITLE
Update processhtml.js

### DIFF
--- a/tasks/processhtml.js
+++ b/tasks/processhtml.js
@@ -28,6 +28,40 @@ module.exports = function (grunt) {
       environment: this.target
     });
 
+    function clone(obj) {
+
+        if(obj == null)
+            return obj;
+
+        var tp = typeof obj;
+		
+        if(tp === 'string' ||
+            tp === 'number' ||
+            tp === 'boolean' ||
+            tp === 'function') {
+            return obj;
+        } else if(tp === 'object') {
+
+            if(obj instanceof Date) {
+                  return new Date(obj.getTime());
+            } else if(obj instanceof RegExp) {
+                return new RegExp(obj.source);
+            } else {
+                var copy = {};
+                var props = Object.getOwnPropertyNames(obj);
+                for(var prop in obj) {
+                    if(obj.hasOwnProperty(prop)){
+                        copy[prop] = clone(obj[prop]);
+                    }
+                }
+                return copy;
+            }
+        } else {
+            throw 'Cannot handle value of type \'' + tp + '\'.';
+        }
+
+    }
+
     var done = this.async();
     var html = new HTMLProcessor(options);
 
@@ -54,7 +88,7 @@ module.exports = function (grunt) {
         var content = html.process(file);
 
         if (options.process) {
-          content = html.template(content, html.data, options.templateSettings);
+          content = html.template(content, clone(html.data), options.templateSettings);
         }
 
         result.push(content);


### PR DESCRIPTION
Please consider adding the following feature that is illustrated in the fork.

The feature clones the data object passed into the template for each page processed. This allows individual pages to override defaults set in Gruntfile.js. 

A use case is a standard configuration that holds for most processed pages (e.g., standard version numbers of CSS/JS imports in the page head) but which needs modification for a small number of pages.

The fork contains working code. A polished version should likely add a clone option in the configuration. A further addition could be a check within the clone function if the data object itself has a clone method that could be used instead.

Many thanks for your work on this plugin!

M.

Matthias Hild