### PR TITLE
Use recent lodash to prevent warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "5.1"
-  - "4.4"
-  - "0.12"
+  - 11
+  - 10
+  - 8
+  - 6
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "htmlprocessor": "^0.2.4",
-    "lodash.clonedeep": "^4.3.2"
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "grunt": "^1.0.1",

--- a/tasks/processhtml.js
+++ b/tasks/processhtml.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-var cloneDeep = require('lodash.clonedeep');
+var lodash = require('lodash');
 var path = require('path');
 var async = require('async');
 
@@ -56,7 +56,7 @@ module.exports = function (grunt) {
         var content = html.process(file);
 
         if (options.process) {
-          content = html.template(content, cloneDeep(html.data), options.templateSettings);
+          content = html.template(content, lodash.cloneDeep(html.data), options.templateSettings);
         }
 
         result.push(content);

--- a/test/expected/conditional_ie/conditional_ie.html
+++ b/test/expected/conditional_ie/conditional_ie.html
@@ -6,7 +6,7 @@
     <title>Conditional IE statement</title>
     <!--[if lte IE 8]>
       <script src="ie8script.js"></script>
-      <link rel="stylesheet" href="ie8.min.css"/>
+      <link rel="stylesheet" href="ie8.min.css">
     <![endif]-->
   </head>
   <body>

--- a/test/expected/inline/inline.html
+++ b/test/expected/inline/inline.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Inline CSS</title>
 
-    <link rel="stylesheet" href="styles.css"/>
+    <link rel="stylesheet" href="styles.css">
 
     <style>
 html {

--- a/test/expected/recursive/recursive.html
+++ b/test/expected/recursive/recursive.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Recursive process included files</title>
 
-    <link rel="stylesheet" href="styles.min.css"/>
+    <link rel="stylesheet" href="styles.min.css">
 
 <script src="script.min.js"></script>
   </head>


### PR DESCRIPTION
First commit fixes the build, since it's currently broken. Second commit switches from `lodash.cloneDeep` to `lodash` in order to prevent a warning message by `npm audit`.