### PR TITLE
Update dependencies to resolve lodash vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-processhtml",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -906,18 +906,11 @@
       }
     },
     "htmlprocessor": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/htmlprocessor/-/htmlprocessor-0.2.6.tgz",
-      "integrity": "sha1-rJ9HfsU3g7jXprZ9e2w1HqXXPTU=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/htmlprocessor/-/htmlprocessor-0.3.1.tgz",
+      "integrity": "sha512-okpkIDUocOTnJEw6Su4onz6XfAjWOAFzYqAl9lvXo3UbS9BxU4nXrpWRPr5V88h47+XssbapYHqqAAHdIlSjXg==",
       "requires": {
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        }
+        "lodash": "^4.17.11"
       }
     },
     "http-signature": {
@@ -1134,9 +1127,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-driver": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-processhtml",
   "description": "Process html files at build time to modify them depending on the release environment",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "homepage": "https://github.com/dciccale/grunt-processhtml",
   "author": {
     "name": "Denis Ciccale",
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "htmlprocessor": "^0.2.4",
-    "lodash": "^4.17.5"
+    "htmlprocessor": "^0.3.1",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
bump lodash from 4.17.5 to 4.17.21 (to resolve [CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337))
bump htmlprocessor from 0.2.4 to 0.3.1
